### PR TITLE
add environment distinguishment

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,52 +1,32 @@
-name: Build, Lint, and Push Docker Image
+name: Build and Push Docker Image
 
 on:
   push:
-    branches: [dev, main]
-  pull_request:
-    branches: [dev, main]
+    branches:
+      - dev
+      - main
 
 jobs:
-  lint-and-check:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set up Python 3.11 (secondary)
-        if: matrix.python-version != '3.11'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Set up Python 3.12 (secondary)
-        if: matrix.python-version != '3.12'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-
   build-and-push:
     runs-on: ubuntu-latest
-    needs: lint-and-check
-    if: github.event_name == 'push'
+    environment: ${{ github.ref == 'refs/heads/main' && 'prd' || 'dev' }}
     env:
       REGISTRY: ${{ vars.REGISTRY_NAME }}
       REPOSITORY: ${{ vars.REPOSITORY_NAME }}
       IMAGE_NAME: aimq
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Set up Docker config.json for DOCR
         run: |
           mkdir -p ~/.docker
           echo "${{ secrets.DOCKER_CONFIG_JSON }}" > ~/.docker/config.json
+
       - name: Set image tag
         id: vars
         run: |
@@ -59,6 +39,7 @@ jobs:
             TAG="${BRANCH}-${SHORT_SHA}"
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         run: |
           chmod +x ./docker/docker-build-push.sh


### PR DESCRIPTION
This pull request modifies the `.github/workflows/docker-build-push.yml` file to streamline the CI workflow for building and pushing Docker images. The most significant changes include removing the linting and Python setup steps, simplifying the branch configuration, and dynamically setting the deployment environment based on the Git branch.

### Workflow simplification:

* Removed the `lint-and-check` job, including Python version setup and matrix strategy, to focus solely on building and pushing Docker images.
* Adjusted the `on` configuration to simplify branch definitions for `push` events.

### Dynamic environment configuration:

* Added logic to dynamically set the deployment environment (`prd` for `main` branch, `dev` for others) in the `build-and-push` job.

### Docker setup enhancements:

* Added steps to configure Docker Buildx and set up the Docker `config.json` for authentication.
* Included a step to execute the Docker build and push script (`docker-build-push.sh`).