### PR TITLE
FIX: run job on pr to main

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - dev
+  pull_request:
+    branches:
+      - dev
       - main
 
 jobs:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the conditions under which the Docker image build and push process is triggered.

Workflow trigger updates:

* [`.github/workflows/docker-build-push.yml`](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10R5-R7): Modified the workflow to trigger on pushes to the `dev` branch and on pull requests targeting the `dev` or `main` branches.